### PR TITLE
[Fix]-Question, Answer : 소프트 삭제(권한 우회 삭제)

### DIFF
--- a/src/main/java/com/dentallink/domain/qna/entity/Answer.java
+++ b/src/main/java/com/dentallink/domain/qna/entity/Answer.java
@@ -42,11 +42,28 @@ public class Answer extends BaseEntity {
         this.content = content;
     }
 
+    /// 일반 사용자 삭제 메서드 - Only 본인 답변
     // 답변 삭제 메서드 (soft delete) + 검증 로직
     // todo 검증 로직 추가
-    public void deleteAnswer() {
-        this.delete();
+    public void deleteAnswer(Long responderId) {
+        validateResponder(responderId);
+        super.delete(); // soft delete - BaseEntity의 delete 메서드 호출
     }
+    /**
+     * 설명
+     * 답변 작성자 (responderId) 본인이 직접 삭제할 때 사용하는 메서드
+     * "내가 작성한 답변을 내가 삭제할 수 있다."는 비즈니스 규칙을 구현
+     * 검증 로직은 validateResponder 메서드에서 수행
+     * 삭제 주체의 권한 검증을 우회하는 로직이 필요할 경우 이 메서드를 수정하거나 별도의 메서드를 추가해야 함
+     * */
+
+    /// 문의글 삭제 시 답변 일괄 삭제 메서드 - 검증 우회용 메서드
+    // todo 삭제 주체의 권한 검증을 우회하는 로직
+    // 답변 강제 삭제 메서드 (soft delete) - 질문 삭제 시 사용 또는 관리자 권한 등 특별한 경우에 사용
+    protected void forceDeleteAnswer() {
+        super.delete(); // soft delete - BaseEntity의 delete 메서드 호출
+    }
+    // protected로 설정하여 Answer 외부에서 직접 호출하지 못하게 함
 
     // 동일한 ID 검증 로직
     public void validateResponder(Long responderId) {

--- a/src/main/java/com/dentallink/domain/qna/entity/Question.java
+++ b/src/main/java/com/dentallink/domain/qna/entity/Question.java
@@ -60,13 +60,35 @@ public class Question extends BaseEntity {
         this.content = content;
     }
 
+    /// 문의글 삭제 시 자신의 문의글 및 답변 일괄 삭제 메서드 - 본인 검증 포함
     // 질문 삭제 메서드 (soft delete) + 검증 로직
     // todo 검증 로직 추가
-    public void deleteQuestion() {
-        this.delete();
+    public void deleteQuestion(Long userId) {
+        validateOwner(userId);
+
+        // 자기 자신 질문 삭제 처리 - soft delete - BaseEntity의 delete 메서드 호출
+        super.delete();
+
+        // 해당 질문에 달린 답변들도 함께 강제 삭제 처리
         if (answerList != null) {
-            answerList.forEach(Answer::deleteAnswer);
+            answerList.forEach(Answer::forceDeleteAnswer);
         }
+        /**
+         * 설명
+         * 질문 작성자 (userId) 본인이 직접 삭제할 때 사용하는 메서드
+         * "내가 작성한 질문을 내가 삭제할 수 있다."는 비즈니스 규칙을 구현
+         * 검증 로직은 validateOwner 메서드에서 수행
+         * 삭제 주체의 권한 검증을 우회하는 로직이 필요할 경우 이 메서드를 수정하거나 별도의 메서드를 추가해야 함
+         *
+         * 문제
+         * 현재 deleteAnswer 메서드는 답변 작성자 (responderId) 본인이 삭제할 때만 호출할 수 있도록 되어 있음
+         * 질문 작성자가 자신의 질문을 삭제할 때 해당 질문에 달린 답변들도 함께 삭제하려고 하면
+         * 답변 작성자와 질문 작성자가 다를 경우 권한 검증에서 예외가 발생함
+         *
+         * 해결 방안
+         * deleteAnswer 메서드에 별도의 삭제 주체 검증 우회 로직을 추가하거나,
+         * Question 엔티티에서 답변 삭제를 직접 처리하는 로직을 구현해야 함
+         * */
     }
 
     // 동일한 ID 검증 로직

--- a/src/main/java/com/dentallink/domain/qna/service/AnswerService.java
+++ b/src/main/java/com/dentallink/domain/qna/service/AnswerService.java
@@ -47,6 +47,6 @@ public class AnswerService {
         Answer answer = get(answerId);
         // 본인 답변만 삭제 가능
         answer.validateResponder(responderId);
-        answer.deleteAnswer(); // soft delete
+        answer.deleteAnswer(responderId); // soft delete
     }
 }

--- a/src/main/java/com/dentallink/domain/qna/service/QuestionService.java
+++ b/src/main/java/com/dentallink/domain/qna/service/QuestionService.java
@@ -48,6 +48,6 @@ public class QuestionService {
     public void delete(Long questionId, Long userId) {
         Question question = getWithAnswers(questionId);
         question.validateOwner(userId);
-        question.deleteQuestion(); // soft delete
+        question.deleteQuestion(userId); // soft delete
     }
 }


### PR DESCRIPTION
## 🎖️ Outline
<!--어떤 작업을 진행하였는지 정리해 주세요. "[ ]" 사이 띄어쓰기를 지우고 'x'(소문자 영어)를 입력하여 체크할 수 있습니다.-->
- [x] 💫 Feature : 기능 구현
- [x] 👾 Bug Fix : 오류 수정
- [ ] 🔨 Refactor : 리팩터링
- [ ] ⚙️ Chore : 기타 유지보수
- [ ] 📝 Documentation : 문서 작업

## 📍 Issue Number
<!-- 이슈 번호를 적어주세요.-->
- Closes #26 

## 📄 Description
<!--해당 PR에 대한 자세한 설명을 적어주세요.-->
<!-- 추천하는 방법은 커밋해시-개별 커밋의 고유 식별 번호-를 작성하고 설명하는 방법입니다.-->
<!-- 예) 761e811-커밋 해시를 사용하면 자동으로 인식합니다.- / reaeMe.md 작성.-->
동일 ID 일 때 검증하는 로직과 삭제를 동시에 하는 메서드로 수정하였습니다.
그리고 문의와 답변을 삭제할 때 사용되는 주체의 권한이 상이함으로 권한 상 충돌 및 예외가 일어날 수 있어서,
답변자의 ID를 우회하고 문의글을 삭제할 때 답변도 함께 삭제되는 메서드를 구현하였습니다.

## 💗 For Reviewers
<!-- 리뷰어들이 더 주의깊게 보면 좋을 곳을 얘기해 주세요. -필수X- -->

## ✔️ PR Checklist
<!--PR은 필수적으로 다음의 체크리스트를 만족해야 합니다! 확인해 주세요. "[ ]" 사이 띄어쓰기를 지우고 'x'(소문자 영어)를 입력하여 완료할 수 있습니다.-->
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
