### PR TITLE
Feat/qna 29 Q&A 문의 상태 변경 및 일문일답 로직 추가

### DIFF
--- a/src/main/java/com/dentallink/domain/qna/controller/AnswerController.java
+++ b/src/main/java/com/dentallink/domain/qna/controller/AnswerController.java
@@ -4,10 +4,12 @@ import com.dentallink.common.response.ApiResponse;
 import com.dentallink.domain.qna.dto.request.AnswerRequestDto;
 import com.dentallink.domain.qna.dto.response.AnswerResponseDto;
 import com.dentallink.domain.qna.service.AnswerService;
+import com.dentallink.domain.user.dto.security.AuthUser;
 import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,15 +22,10 @@ public class AnswerController {
     // 답변 등록 API answer create api
     @PostMapping
     public ResponseEntity<ApiResponse<AnswerResponseDto.AnswerResponse>> createAnswer(
-            /**
-             * responderId를 @RequestParam으로 직접 전달받는 것은 심각한 보안 취약점을 유발할 수 있습니다.
-             * 이를 통해 다른 사용자의 ID로 답변을 등록하는 등의 어뷰징이 가능해집니다.
-             * 사용자 ID는 Spring Security의 AuthenticationPrincipal 어노테이션 등을 사용하여 현재 인증된 사용자의 정보를 가져와야 합니다.
-             * 이 문제는 updateAnswer와 deleteAnswer 메소드에도 동일하게 적용됩니다.
-             * */
-            @RequestParam Long responderId,
+            @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody AnswerRequestDto.AnswerCreateRequest req
     ) {
+        Long responderId = authUser.getUserId();    // 인증된 사용자 ID 사용
         return ApiResponse.created(
                 answerService.create(req.questionId(), responderId, req.content()),
                 "답변 등록 완료"
@@ -50,9 +47,10 @@ public class AnswerController {
     @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> updateAnswer(
             @PathVariable Long id,
-            @RequestParam Long responderId,
+            @AuthenticationPrincipal AuthUser authUser,
             @RequestBody AnswerRequestDto.AnswerUpdateRequest req
     ) {
+        Long responderId = authUser.getUserId();    // 인증된 사용자 ID 사용
         answerService.update(id, responderId, req.content());
         return ApiResponse.success(null, "답변 수정 완료");
     }
@@ -61,8 +59,9 @@ public class AnswerController {
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> deleteAnswer(
             @PathVariable Long id,
-            @RequestParam Long responderId
+            @AuthenticationPrincipal AuthUser authUser
     ) {
+        Long responderId = authUser.getUserId();    // 인증된 사용자 ID 사용
         answerService.delete(id, responderId);
         return ApiResponse.deleteSuccess("답변 삭제 완료");
     }

--- a/src/main/java/com/dentallink/domain/qna/controller/QuestionController.java
+++ b/src/main/java/com/dentallink/domain/qna/controller/QuestionController.java
@@ -19,7 +19,7 @@ public class QuestionController {
 
     private final QuestionService questionService;
 
-    // 질문 등록 API question create api
+    // 문의 등록 API question create api
     @PostMapping
     public ResponseEntity<ApiResponse<QuestionResponseDto.QuestionResponse>> createQuestion(
             @AuthenticationPrincipal AuthUser authUser,
@@ -32,7 +32,7 @@ public class QuestionController {
         );
     }
 
-    // 질문 조회 APi question read api
+    // 문의 조회 APi question read api
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<QuestionResponseDto.QuestionResponse>> getQuestion(
             @PathVariable Long id
@@ -43,7 +43,7 @@ public class QuestionController {
         );
     }
 
-    // 질문 수정 API question update api
+    // 문의 수정 API question update api
     @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> updateQuestion(
             // todo 보안 취약점 확인
@@ -56,7 +56,7 @@ public class QuestionController {
         return ApiResponse.success(null, "문의 수정 완료");
     }
 
-    // 질문 삭제 API question delete api
+    // 문의 삭제 API question delete api
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> deleteQuestion(
             // todo 보안 취약점 확인

--- a/src/main/java/com/dentallink/domain/qna/controller/QuestionController.java
+++ b/src/main/java/com/dentallink/domain/qna/controller/QuestionController.java
@@ -4,10 +4,12 @@ import com.dentallink.common.response.ApiResponse;
 import com.dentallink.domain.qna.dto.request.QuestionRequestDto;
 import com.dentallink.domain.qna.dto.response.QuestionResponseDto;
 import com.dentallink.domain.qna.service.QuestionService;
+import com.dentallink.domain.user.dto.security.AuthUser;
 import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,15 +22,10 @@ public class QuestionController {
     // 질문 등록 API question create api
     @PostMapping
     public ResponseEntity<ApiResponse<QuestionResponseDto.QuestionResponse>> createQuestion(
-            /**
-             * userId를 @RequestParam으로 전달받는 것은 심각한 보안 취약점을 야기할 수 있습니다.
-             * 악의적인 사용자가 다른 사용자의 ID를 사용하여 질문을 생성, 수정, 삭제할 수 있습니다.
-             * 현재 인증된 사용자의 ID는 Spring Security의 AuthenticationPrincipal 등을 통해 보안 컨텍스트에서 안전하게 얻어와야 합니다.
-             * 이 문제는 updateQuestion, deleteQuestion 메소드에도 동일하게 적용됩니다.
-             * */
-            @RequestParam Long userId,
+            @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody QuestionRequestDto.QuestionCreateRequest req
     ) {
+        Long userId = authUser.getUserId();     // 인증된 사용자 ID 사용
         return ApiResponse.created(
                 questionService.create(userId, req.hospitalId(), req.title(), req.content()),
                 "문의 등록 완료"
@@ -51,9 +48,10 @@ public class QuestionController {
     public ResponseEntity<ApiResponse<Void>> updateQuestion(
             // todo 보안 취약점 확인
             @PathVariable Long id,
-            @RequestParam Long userId,
+            @AuthenticationPrincipal AuthUser authUser,
             @RequestBody QuestionRequestDto.QuestionUpdateRequest req
     ) {
+        Long userId = authUser.getUserId();     // 인증된 사용자 ID 사용
         questionService.update(id, userId, req.title(), req.content());
         return ApiResponse.success(null, "문의 수정 완료");
     }
@@ -63,8 +61,9 @@ public class QuestionController {
     public ResponseEntity<ApiResponse<Void>> deleteQuestion(
             // todo 보안 취약점 확인
             @PathVariable Long id,
-            @RequestParam Long userId
+            @AuthenticationPrincipal AuthUser authUser
     ) {
+        Long userId = authUser.getUserId();     // 인증된 사용자 ID 사용
         questionService.delete(id, userId);
         return ApiResponse.deleteSuccess("문의 삭제 완료");
     }

--- a/src/main/java/com/dentallink/domain/qna/dto/request/QuestionRequestDto.java
+++ b/src/main/java/com/dentallink/domain/qna/dto/request/QuestionRequestDto.java
@@ -5,14 +5,14 @@ import jakarta.validation.constraints.NotNull;
 
 public class QuestionRequestDto {
 
-    // 질문 등록 요청 DTO question create request dto
+    // 문의 등록 요청 DTO question create request dto
     public record QuestionCreateRequest(
             @NotNull Long hospitalId,
             @NotBlank String title,
             @NotBlank String content
     ) {}
 
-    // 질문 수정 요청 DTO question update request dto
+    // 문의 수정 요청 DTO question update request dto
     public record QuestionUpdateRequest(
             @NotBlank String title,
             @NotBlank String content

--- a/src/main/java/com/dentallink/domain/qna/entity/Answer.java
+++ b/src/main/java/com/dentallink/domain/qna/entity/Answer.java
@@ -44,8 +44,6 @@ public class Answer extends BaseEntity {
     }
 
     /// 일반 사용자 삭제 메서드 - Only 본인 답변
-    // 답변 삭제 메서드 (soft delete) + 검증 로직
-    // todo 검증 로직 추가
     public void deleteAnswer(Long responderId) {
         validateResponder(responderId);
         super.delete(); // soft delete - BaseEntity의 delete 메서드 호출
@@ -59,8 +57,7 @@ public class Answer extends BaseEntity {
      * */
 
     /// 문의글 삭제 시 답변 일괄 삭제 메서드 - 검증 우회용 메서드
-    // todo 삭제 주체의 권한 검증을 우회하는 로직
-    // 답변 강제 삭제 메서드 (soft delete) - 질문 삭제 시 사용 또는 관리자 권한 등 특별한 경우에 사용
+    // 질문 삭제 시 사용 또는 관리자 권한 등 특별한 경우에 사용
     protected void forceDeleteAnswer() {
         super.delete(); // soft delete - BaseEntity의 delete 메서드 호출
     }

--- a/src/main/java/com/dentallink/domain/qna/entity/Answer.java
+++ b/src/main/java/com/dentallink/domain/qna/entity/Answer.java
@@ -57,7 +57,7 @@ public class Answer extends BaseEntity {
      * */
 
     /// 문의글 삭제 시 답변 일괄 삭제 메서드 - 검증 우회용 메서드
-    // 질문 삭제 시 사용 또는 관리자 권한 등 특별한 경우에 사용
+    // 문의 삭제 시 사용 또는 관리자 권한 등 특별한 경우에 사용
     protected void forceDeleteAnswer() {
         super.delete(); // soft delete - BaseEntity의 delete 메서드 호출
     }

--- a/src/main/java/com/dentallink/domain/qna/entity/Answer.java
+++ b/src/main/java/com/dentallink/domain/qna/entity/Answer.java
@@ -34,6 +34,7 @@ public class Answer extends BaseEntity {
         answer.question = question;
         answer.responderId = responderId;
         answer.content = content;
+        question.getAnswerList().add(answer); // Answer of() 생성자에서 양방향 연관관계 설정
         return answer;
     }
 

--- a/src/main/java/com/dentallink/domain/qna/entity/Question.java
+++ b/src/main/java/com/dentallink/domain/qna/entity/Question.java
@@ -1,6 +1,7 @@
 package com.dentallink.domain.qna.entity;
 
 import com.dentallink.common.entity.BaseEntity;
+import com.dentallink.domain.qna.enums.QuestionStatus;
 import com.dentallink.domain.qna.exception.QnaErrorCode;
 import com.dentallink.domain.qna.exception.QnaException;
 import jakarta.persistence.*;

--- a/src/main/java/com/dentallink/domain/qna/entity/Question.java
+++ b/src/main/java/com/dentallink/domain/qna/entity/Question.java
@@ -33,22 +33,42 @@ public class Question extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    // 질문 삭제 시 해당 질문에 달린 답변들도 함께 삭제
-    @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
+    // 문의 상태 관리
+    @Enumerated(EnumType.STRING)
+    @Column(name = "question_status", nullable = false)
+    private QuestionStatus questionStatus = QuestionStatus.AWAITING;    // 기본값 설정_ "답변 대기중"
 
+    // 문의 삭제 시 해당 문의에 달린 답변들도 함께 삭제
+    @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
     private List<Answer> answerList = new ArrayList<>();
 
-    // 질문 생성 메서드
+    // 문의 생성 메서드
     public static Question of(Long userId, Long hospitalId, String title, String content) {
         Question question = new Question();
         question.userId = userId;
         question.hospitalId = hospitalId;
         question.title = title;
         question.content = content;
+        question.questionStatus = QuestionStatus.AWAITING;
         return question;
     }
 
-    // 질문 수정 메서드
+    // 문의 상태 변경 메서드 - 답변 대기중
+    public void awaitingMark() {
+        this.questionStatus = QuestionStatus.AWAITING;
+    }
+
+    // 문의 상태 변경 메서드 - 답변 완료
+    public void answeredMark() {
+        this.questionStatus = QuestionStatus.ANSWERED;
+    }
+
+    // 문의 상태 변경 메서드 - 재문의
+    public void requestedMark() {
+        this.questionStatus = QuestionStatus.REQUESTED;
+    }
+
+    // 문의 수정 메서드
     public void updateQuestion(String title, String content) {
         this.title = title;
         this.content = content;

--- a/src/main/java/com/dentallink/domain/qna/entity/Question.java
+++ b/src/main/java/com/dentallink/domain/qna/entity/Question.java
@@ -57,14 +57,10 @@ public class Question extends BaseEntity {
     /// 문의글 삭제 시 자신의 문의글 및 답변 일괄 삭제 메서드 - 본인 검증 포함
     public void deleteQuestion(Long userId) {
         validateOwner(userId);
-
-        // 자기 자신 질문 삭제 처리 - soft delete
-        super.delete();
-
-        // 해당 질문에 달린 답변들도 함께 강제 삭제 처리
-        answerList.forEach(Answer::forceDeleteAnswer);
+        super.delete();     // 자기 자신 문의 삭제 처리 - soft delete
+        answerList.forEach(Answer::forceDeleteAnswer);      // 해당 문의에 달린 답변들도 함께 강제 삭제 처리
         /**
-         * 질문 작성자가 자신의 질문을 삭제할 때 사용하는 메서드.
+         * 문의 작성자가 자신의 문의를 삭제할 때 사용하는 메서드.
          * - 작성자 본인 여부 검증
          * - soft delete 처리
          * - 관련 답변 모두 강제 삭제

--- a/src/main/java/com/dentallink/domain/qna/entity/Question.java
+++ b/src/main/java/com/dentallink/domain/qna/entity/Question.java
@@ -64,7 +64,8 @@ public class Question extends BaseEntity {
         this.questionStatus = QuestionStatus.ANSWERED;
     }
 
-    // 문의 상태 변경 메서드 - 재문의
+    //todo 추후에 확장할 것
+    // 문의 상태 변경 메서드 - 재문의(답변 요청)
     public void requestedMark() {
         this.questionStatus = QuestionStatus.REQUESTED;
     }
@@ -75,7 +76,7 @@ public class Question extends BaseEntity {
         this.content = content;
     }
 
-    /// 문의글 삭제 시 자신의 문의글 및 답변 일괄 삭제 메서드 - 본인 검증 포함
+    // 문의글 삭제 시 자신의 문의글 및 답변 일괄 삭제 메서드 - 본인 검증 포함
     public void deleteQuestion(Long userId) {
         validateOwner(userId);
         super.delete();     // 자기 자신 문의 삭제 처리 - soft delete

--- a/src/main/java/com/dentallink/domain/qna/entity/Question.java
+++ b/src/main/java/com/dentallink/domain/qna/entity/Question.java
@@ -35,13 +35,7 @@ public class Question extends BaseEntity {
 
     // 질문 삭제 시 해당 질문에 달린 답변들도 함께 삭제
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
-    // todo: List.of() 제거 검토
-    /**
-     * answerList를 List.of()로 초기화하면 불변 리스트가 생성됩니다.
-     * JPA가 엔티티를 로드할 때는 이 컬렉션을 자체 구현으로 교체하지만,
-     * 새로 생성된 Question 객체의 answerList에 요소를 추가하려고 하면 UnsupportedOperationException이 발생할 수 있습니다.
-     * 안전하게 가변 리스트인 new ArrayList<>()로 초기화하는 것이 좋습니다.
-     * */
+
     private List<Answer> answerList = new ArrayList<>();
 
     // 질문 생성 메서드
@@ -61,34 +55,20 @@ public class Question extends BaseEntity {
     }
 
     /// 문의글 삭제 시 자신의 문의글 및 답변 일괄 삭제 메서드 - 본인 검증 포함
-    // 질문 삭제 메서드 (soft delete) + 검증 로직
-    // todo 검증 로직 추가
     public void deleteQuestion(Long userId) {
         validateOwner(userId);
 
-        // 자기 자신 질문 삭제 처리 - soft delete - BaseEntity의 delete 메서드 호출
+        // 자기 자신 질문 삭제 처리 - soft delete
         super.delete();
 
         // 해당 질문에 달린 답변들도 함께 강제 삭제 처리
-        if (answerList != null) {
-            answerList.forEach(Answer::forceDeleteAnswer);
-        }
+        answerList.forEach(Answer::forceDeleteAnswer);
         /**
-         * 설명
-         * 질문 작성자 (userId) 본인이 직접 삭제할 때 사용하는 메서드
-         * "내가 작성한 질문을 내가 삭제할 수 있다."는 비즈니스 규칙을 구현
-         * 검증 로직은 validateOwner 메서드에서 수행
-         * 삭제 주체의 권한 검증을 우회하는 로직이 필요할 경우 이 메서드를 수정하거나 별도의 메서드를 추가해야 함
-         *
-         * 문제
-         * 현재 deleteAnswer 메서드는 답변 작성자 (responderId) 본인이 삭제할 때만 호출할 수 있도록 되어 있음
-         * 질문 작성자가 자신의 질문을 삭제할 때 해당 질문에 달린 답변들도 함께 삭제하려고 하면
-         * 답변 작성자와 질문 작성자가 다를 경우 권한 검증에서 예외가 발생함
-         *
-         * 해결 방안
-         * deleteAnswer 메서드에 별도의 삭제 주체 검증 우회 로직을 추가하거나,
-         * Question 엔티티에서 답변 삭제를 직접 처리하는 로직을 구현해야 함
-         * */
+         * 질문 작성자가 자신의 질문을 삭제할 때 사용하는 메서드.
+         * - 작성자 본인 여부 검증
+         * - soft delete 처리
+         * - 관련 답변 모두 강제 삭제
+         */
     }
 
     // 동일한 ID 검증 로직

--- a/src/main/java/com/dentallink/domain/qna/enums/QuestionStatus.java
+++ b/src/main/java/com/dentallink/domain/qna/enums/QuestionStatus.java
@@ -1,0 +1,18 @@
+package com.dentallink.domain.qna.enums;
+
+public enum QuestionStatus {
+
+    AWAITING("답변 대기 중"),    // 최초 문의 상태
+    ANSWERED("답변 완료"),      // 답변 등록 시 변경
+    REQUESTED("재문의");        // 사용자가 재문의 시 변경
+
+    private final String description;
+
+    QuestionStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/dentallink/domain/qna/exception/QnaErrorCode.java
+++ b/src/main/java/com/dentallink/domain/qna/exception/QnaErrorCode.java
@@ -18,6 +18,9 @@ public enum QnaErrorCode implements ErrorCode {
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "답변글을 찾을 수 없습니다."),
     ANSWER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "본인 답변글만 수정하거나 삭제할 수 있습니다."),
 
+    // 1개 문의에는 1개 답변만 허용
+    ANSWER_DUPLICATE(HttpStatus.BAD_REQUEST, "하나의 문의에는 하나의 답변만 작성할 수 있습니다."),
+
     // ====== Validation ======
     INVALID_QNA_INPUT(HttpStatus.BAD_REQUEST, "잘못된 QnA 요청입니다.");
 

--- a/src/main/java/com/dentallink/domain/qna/repository/AnswerRepository.java
+++ b/src/main/java/com/dentallink/domain/qna/repository/AnswerRepository.java
@@ -11,6 +11,9 @@ public interface AnswerRepository extends JpaRepository<Answer,Long> {
     // 삭제되지 않은 답변 조회
     Optional<Answer> findByIdAndDeletedFalse(Long id);
 
+    // 1개의 문의에는 1개의 답변만 허용
+    boolean existsByQuestionAndDeletedFalse(Long questionId);
+
     // 특정 문의글에 달린 삭제되지 않은 답변들 조회
     List<Answer> findByQuestion_IdAndDeletedFalse(Long questionId);
 

--- a/src/main/java/com/dentallink/domain/qna/service/AnswerService.java
+++ b/src/main/java/com/dentallink/domain/qna/service/AnswerService.java
@@ -24,6 +24,9 @@ public class AnswerService {
         Question question = questionRepository.findByIdAndDeletedFalse(questionId)
                          .orElseThrow(() -> new QnaException(QnaErrorCode.QUESTION_NOT_FOUND));
         Answer saved = answerRepository.save(Answer.of(question, responderId, content));
+
+        // 문의 상태 변경 : Awaiting(기본값, 답변 대기 중) -> Answered (답변완료)
+        question.answeredMark();
         return AnswerResponseDto.AnswerResponse.from(saved);
     }
 
@@ -46,5 +49,9 @@ public class AnswerService {
     public void delete(Long answerId, Long responderId) {
         Answer answer = get(answerId);
         answer.deleteAnswer(responderId); // soft delete
+
+        // 답변 삭제 시 문의 상태 변경 : Answered -> Awaiting
+        Question question = answer.getQuestion();
+        question.awaitingMark();
     }
 }

--- a/src/main/java/com/dentallink/domain/qna/service/AnswerService.java
+++ b/src/main/java/com/dentallink/domain/qna/service/AnswerService.java
@@ -45,8 +45,6 @@ public class AnswerService {
     // 비즈니스 로직 작성 delete
     public void delete(Long answerId, Long responderId) {
         Answer answer = get(answerId);
-        // 본인 답변만 삭제 가능
-        answer.validateResponder(responderId);
         answer.deleteAnswer(responderId); // soft delete
     }
 }

--- a/src/main/java/com/dentallink/domain/qna/service/AnswerService.java
+++ b/src/main/java/com/dentallink/domain/qna/service/AnswerService.java
@@ -23,6 +23,20 @@ public class AnswerService {
     public AnswerResponseDto.AnswerResponse create(Long questionId, Long responderId, String content) {
         Question question = questionRepository.findByIdAndDeletedFalse(questionId)
                          .orElseThrow(() -> new QnaException(QnaErrorCode.QUESTION_NOT_FOUND));
+
+        // 하나의 문의에는 하나의 답변만 작성 가능
+        // ver1
+        if (answerRepository.existsByQuestionAndDeletedFalse(questionId)) {
+            throw new QnaException(QnaErrorCode.ANSWER_DUPLICATE);
+        }
+
+        // ver2
+        // boolean existsAnswer = answerRepository.findByQuestionAndDeletedFalse(questionId);
+        // if (existsAnswer) {
+        //     throw new QnaException(QnaErrorCode.ANSWER_DUPLICATE);
+        // }
+
+        // 답변 생성
         Answer saved = answerRepository.save(Answer.of(question, responderId, content));
 
         // 문의 상태 변경 : Awaiting(기본값, 답변 대기 중) -> Answered (답변완료)

--- a/src/main/java/com/dentallink/domain/qna/service/QuestionService.java
+++ b/src/main/java/com/dentallink/domain/qna/service/QuestionService.java
@@ -47,7 +47,6 @@ public class QuestionService {
     // 비즈니스 로직 작성 delete
     public void delete(Long questionId, Long userId) {
         Question question = getWithAnswers(questionId);
-        question.validateOwner(userId);
         question.deleteQuestion(userId); // soft delete
     }
 }

--- a/src/main/java/com/dentallink/domain/qna/service/QuestionService.java
+++ b/src/main/java/com/dentallink/domain/qna/service/QuestionService.java
@@ -39,7 +39,7 @@ public class QuestionService {
     // 비즈니스 로직 작성 update
     public void update(Long questionId, Long userId, String title, String content) {
         Question question = get(questionId);
-        // 본인 질문만 수정 가능
+        // 본인 문의만 수정 가능
         question.validateOwner(userId);
         question.updateQuestion(title, content);
     }


### PR DESCRIPTION
## 🎖️ Outline
<!--어떤 작업을 진행하였는지 정리해 주세요. "[ ]" 사이 띄어쓰기를 지우고 'x'(소문자 영어)를 입력하여 체크할 수 있습니다.-->
- [x] 💫 Feature : 기능 구현
- [ ] 👾 Bug Fix : 오류 수정
- [ ] 🔨 Refactor : 리팩터링
- [x] ⚙️ Chore : 기타 유지보수
- [ ] 📝 Documentation : 문서 작업

## 📍 Issue Number
<!-- 이슈 번호를 적어주세요.-->
- Closes #29 

## 📄 Description
<!--해당 PR에 대한 자세한 설명을 적어주세요.-->
<!-- 추천하는 방법은 커밋해시-개별 커밋의 고유 식별 번호-를 작성하고 설명하는 방법입니다.-->
<!-- 예) 761e811-커밋 해시를 사용하면 자동으로 인식합니다.- / reaeMe.md 작성.-->
0. 사용자 인증이 되었을 때 생성 및 수정, 삭제가 가능하도록 함
1. 문의 상태 표시를 위해서 Enum 추가
2. 문의 상태 표시 변경을 위한 메서드 추가 (Question 엔티티 참고)
3. 일문일답 (한 개 문의에는 한 개 답변 규칙) 추가로 문의하면 "재문의" 상태로 변경
4. 문의 생성 시 자동으로 "답변 대기 중" 으로 표시
5. 답변 삭제 시 문의 상태 "답변 완료" -> "답변 대기 중"


고민되는 부분 ver1, ver2 으로 나눔
<img width="1023" height="552" alt="image" src="https://github.com/user-attachments/assets/7ec27e1b-7186-4b3f-b551-186961b18c00" />


## 💗 For Reviewers
<!-- 리뷰어들이 더 주의깊게 보면 좋을 곳을 얘기해 주세요. -필수X- -->

## ✔️ PR Checklist
<!--PR은 필수적으로 다음의 체크리스트를 만족해야 합니다! 확인해 주세요. "[ ]" 사이 띄어쓰기를 지우고 'x'(소문자 영어)를 입력하여 완료할 수 있습니다.-->
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
