### PR TITLE
관계자가 특정 accountId를 입력하면 해당 accountId의 계좌에 포인트를 지급

### DIFF
--- a/src/main/java/com/dentallink/domain/pointAccount/controller/PointAccountController.java
+++ b/src/main/java/com/dentallink/domain/pointAccount/controller/PointAccountController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,15 +37,19 @@ public class PointAccountController {
         return ApiResponse.success(response, "잔액을 확인하였습니다.");
     }
 
-    // 관계자가 특정 포인트 계좌에 포인트를 충전하는 메서드
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/deposit")
-    public ResponseEntity<ApiResponse<PointAccountDepositResponse>> chargePointAccount(
+    public ResponseEntity<ApiResponse<PointAccountDepositResponse>> depositPointAccount(
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody PointAccountRequest request
-    ){
-        PointAccountDepositResponse response = pointAccountInternalService.depositPointAccount(authUser.getUserId(), request.amount());
+    ) {
+        PointAccountDepositResponse response = pointAccountInternalService.depositPointAccount(
+                request.accountId(),   //
+                request.amount()
+        );
         return ApiResponse.success(response, "포인트 충전에 성공했습니다.");
     }
+
 
     // 포인트를 현금으로 전환(지금은 그냥 point의 balance 값을 줄이는 용도)
     @PostMapping("/withdraw")

--- a/src/main/java/com/dentallink/domain/pointAccount/dto/request/PointAccountRequest.java
+++ b/src/main/java/com/dentallink/domain/pointAccount/dto/request/PointAccountRequest.java
@@ -4,6 +4,9 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record PointAccountRequest(
+        @NotNull(message = "계좌 ID를 입력해주세요.")
+        Long accountId,
+
         @NotNull(message = "금액을 입력해주세요.")
         @Min(value = 1000, message = "최소 금액은 1000원입니다.")
         Long amount


### PR DESCRIPTION
## 🎖️ Outline
<!--어떤 작업을 진행하였는지 정리해 주세요. "[ ]" 사이 띄어쓰기를 지우고 'x'(소문자 영어)를 입력하여 체크할 수 있습니다.-->
- [ ] 💫 Feature : 기능 구현
- [ ] 👾 Bug Fix : 오류 수정
- [ ] 🔨 Refactor : 리팩터링
- [ ] ⚙️ Chore : 기타 유지보수
- [ ] 📝 Documentation : 문서 작업

## 📍 Issue Number
<!-- 이슈 번호를 적어주세요.-->
- Closes #이슈번호

## 📄 Description
<!--해당 PR에 대한 자세한 설명을 적어주세요.-->
<!-- 추천하는 방법은 커밋해시-개별 커밋의 고유 식별 번호-를 작성하고 설명하는 방법입니다.-->
<!-- 예) 761e811-커밋 해시를 사용하면 자동으로 인식합니다.- / reaeMe.md 작성.-->

dto에 
@NotNull(message = "계좌 ID를 입력해주세요.")
        Long accountId, 
를 추가해 관리자가 특정 accountId에 포인트를 지급

contoller에 
@PreAuthorize("hasRole('ADMIN')") 어노테이션을 통해 관리자만 포인트를 지급할 수 있도록 변경 

## 💗 For Reviewers
<!-- 리뷰어들이 더 주의깊게 보면 좋을 곳을 얘기해 주세요. -필수X- -->

## ✔️ PR Checklist
<!--PR은 필수적으로 다음의 체크리스트를 만족해야 합니다! 확인해 주세요. "[ ]" 사이 띄어쓰기를 지우고 'x'(소문자 영어)를 입력하여 완료할 수 있습니다.-->
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
