### PR TITLE
docs: Swagger 문서화 어노테이션 추가 및 ApiResponse 리네임

### DIFF
--- a/src/main/java/com/dentallink/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dentallink/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.dentallink.common.exception;
 
-import com.dentallink.common.response.ApiResponse;
+import com.dentallink.common.response.CommonApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,13 +13,13 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(GlobalException.class)
-    public ResponseEntity<ApiResponse<Object>> handleGlobalException(GlobalException ex) {
+    public ResponseEntity<CommonApiResponse<Object>> handleGlobalException(GlobalException ex) {
         log.error("비즈니스 오류 발생 ", ex);
         return handleExceptionInternal(ex.getErrorCode());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Object>> handleValidationException(MethodArgumentNotValidException ex) {
+    public ResponseEntity<CommonApiResponse<Object>> handleValidationException(MethodArgumentNotValidException ex) {
         log.error("유효성 검사 실패 ", ex);
         String errorMessage = ex.getBindingResult()
                 .getAllErrors()
@@ -28,21 +28,21 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(errorMessage));
+                .body(CommonApiResponse.error(errorMessage));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Object>> handleServerException(Exception ex) {
+    public ResponseEntity<CommonApiResponse<Object>> handleServerException(Exception ex) {
         log.error("서버 오류 발생", ex);
         return ResponseEntity
                 .status(CommonErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
-                .body(ApiResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR));
+                .body(CommonApiResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR));
     }
 
-    private ResponseEntity<ApiResponse<Object>> handleExceptionInternal(ErrorCode errorCode) {
+    private ResponseEntity<CommonApiResponse<Object>> handleExceptionInternal(ErrorCode errorCode) {
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(ApiResponse.error(errorCode));
+                .body(CommonApiResponse.error(errorCode));
     }
 }
 

--- a/src/main/java/com/dentallink/common/response/CommonApiResponse.java
+++ b/src/main/java/com/dentallink/common/response/CommonApiResponse.java
@@ -9,14 +9,14 @@ import org.springframework.http.ResponseEntity;
 import java.time.LocalDateTime;
 
 @Getter
-public class ApiResponse<T> {
+public class CommonApiResponse<T> {
 
     private final boolean success;
     private final String message;
     private final T data;
     private final LocalDateTime timestamp;
 
-    private ApiResponse(boolean success, String message, T data, LocalDateTime timestamp) {
+    private CommonApiResponse(boolean success, String message, T data, LocalDateTime timestamp) {
         this.success = success;
         this.message = message;
         this.data = data;
@@ -31,10 +31,10 @@ public class ApiResponse<T> {
      * @param message 응답 메세지
      * @return HTTP 201 Created 응답과 함께 생성된 데이터가 포함된 ApiResponseDto
      */
-    public static <T> ResponseEntity<ApiResponse<T>> created(T data, String message) {
+    public static <T> ResponseEntity<CommonApiResponse<T>> created(T data, String message) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(new ApiResponse<>(true, message, data, LocalDateTime.now()));
+                .body(new CommonApiResponse<>(true, message, data, LocalDateTime.now()));
     }
 
     /**
@@ -45,8 +45,8 @@ public class ApiResponse<T> {
      * @param message 응답 메세지
      * @return HTTP 200 OK 응답과 함께 성공 데이터가 포함된 ApiResponseDto
      */
-    public static <T> ResponseEntity<ApiResponse<T>> success(T data, String message) {
-        return ResponseEntity.ok(new ApiResponse<>(true, message, data, LocalDateTime.now()));
+    public static <T> ResponseEntity<CommonApiResponse<T>> success(T data, String message) {
+        return ResponseEntity.ok(new CommonApiResponse<>(true, message, data, LocalDateTime.now()));
     }
 
     /**
@@ -56,8 +56,8 @@ public class ApiResponse<T> {
      * @param message 응답 메세지
      * @return HTTP 200 OK 응답과 함께 응답 메세지만 반환
      */
-    public static <T> ResponseEntity<ApiResponse<T>> deleteSuccess(String message) {
-        return ResponseEntity.ok(new ApiResponse<>(true, message, null, LocalDateTime.now()));
+    public static <T> ResponseEntity<CommonApiResponse<T>> deleteSuccess(String message) {
+        return ResponseEntity.ok(new CommonApiResponse<>(true, message, null, LocalDateTime.now()));
     }
 
     /**
@@ -65,8 +65,8 @@ public class ApiResponse<T> {
      * 이 메서드는 `ErrorCode` 객체에서 제공하는 메세지를 사용하여 메세지를 반환
      * `data`는 항상 `null' 값을 반환하며 `success` 값은 `false`로 반환
      */
-    public static <T> ApiResponse<T> error(ErrorCode error) {
-        return new ApiResponse<>(false, error.getMessage(), null, LocalDateTime.now());
+    public static <T> CommonApiResponse<T> error(ErrorCode error) {
+        return new CommonApiResponse<>(false, error.getMessage(), null, LocalDateTime.now());
     }
 
     /**
@@ -74,8 +74,8 @@ public class ApiResponse<T> {
      * 이 메서드는 DTO 필드에 지정된 Valid 어노테이션에서의 메세지를 반환
      * `data`는 항상 `null' 값을 반환하며 `success` 값은 `false`로 반환
      */
-    public static <T> ApiResponse<T> error(String message) {
-        return new ApiResponse<>(false, message, null, LocalDateTime.now());
+    public static <T> CommonApiResponse<T> error(String message) {
+        return new CommonApiResponse<>(false, message, null, LocalDateTime.now());
     }
 
     /**
@@ -86,13 +86,13 @@ public class ApiResponse<T> {
      * @param message 응답 메세지
      * @return HTTP 200 OK 응답과 함께 PageResponse가 포함된 ApiResponse
      */
-    public static <T> ResponseEntity<ApiResponse<PageResponse<T>>> pageSuccess(Page<T> page, String message) {
+    public static <T> ResponseEntity<CommonApiResponse<PageResponse<T>>> pageSuccess(Page<T> page, String message) {
         PageResponse<T> data = PageResponse.fromPage(page);
-        return ResponseEntity.ok(new ApiResponse<>(true, message, data, LocalDateTime.now()));
+        return ResponseEntity.ok(new CommonApiResponse<>(true, message, data, LocalDateTime.now()));
     }
 
-    public static <T> ResponseEntity<ApiResponse<PageResponse<T>>> pageSuccess(PageResponse<T> response, String message) {
-        return ResponseEntity.ok(new ApiResponse<>(true, message, response, LocalDateTime.now()));
+    public static <T> ResponseEntity<CommonApiResponse<PageResponse<T>>> pageSuccess(PageResponse<T> response, String message) {
+        return ResponseEntity.ok(new CommonApiResponse<>(true, message, response, LocalDateTime.now()));
     }
 }
 

--- a/src/main/java/com/dentallink/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dentallink/domain/auth/controller/AuthController.java
@@ -1,17 +1,16 @@
 package com.dentallink.domain.auth.controller;
 
-import com.dentallink.common.response.ApiResponse;
+import com.dentallink.common.response.CommonApiResponse;
 import com.dentallink.common.utility.JwtUtil;
 import com.dentallink.domain.auth.dto.request.LoginRequest;
 import com.dentallink.domain.auth.service.AuthServiceImpl;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static com.dentallink.common.response.ApiResponse.success;
+import static com.dentallink.common.response.CommonApiResponse.success;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,7 +21,7 @@ public class AuthController {
 
     // 로그인 로직
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<Void>> login(
+    public ResponseEntity<CommonApiResponse<Void>> login(
             @Valid @RequestBody LoginRequest request,
             HttpServletResponse response
     ) {
@@ -48,7 +47,7 @@ public class AuthController {
 
     // 로그아웃
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(
+    public ResponseEntity<CommonApiResponse<Void>> logout(
             @RequestHeader(JwtUtil.AUTHORIZATION_HEADER) String authorizationHeader
     ) {
         if (authorizationHeader != null && authorizationHeader.startsWith(JwtUtil.BEARER_PREFIX)) {

--- a/src/main/java/com/dentallink/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/dentallink/domain/favorite/controller/FavoriteController.java
@@ -1,6 +1,6 @@
 package com.dentallink.domain.favorite.controller;
 
-import com.dentallink.common.response.ApiResponse;
+import com.dentallink.common.response.CommonApiResponse;
 import com.dentallink.domain.favorite.enums.FavoriteAction;
 import com.dentallink.domain.favorite.service.FavoriteService;
 import com.dentallink.domain.user.dto.security.AuthUser;
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.dentallink.common.response.ApiResponse.success;
+import static com.dentallink.common.response.CommonApiResponse.success;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,7 +22,7 @@ public class FavoriteController {
     private final FavoriteService favoriteService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<Boolean>> toggleFavorite(
+    public ResponseEntity<CommonApiResponse<Boolean>> toggleFavorite(
             @PathVariable Long hospitalId,
             @AuthenticationPrincipal AuthUser authUser
     ) {

--- a/src/main/java/com/dentallink/domain/hospital/controller/HospitalController.java
+++ b/src/main/java/com/dentallink/domain/hospital/controller/HospitalController.java
@@ -1,6 +1,6 @@
 package com.dentallink.domain.hospital.controller;
 
-import com.dentallink.common.response.ApiResponse;
+import com.dentallink.common.response.CommonApiResponse;
 import com.dentallink.common.response.PageResponse;
 import com.dentallink.domain.hospital.dto.request.HospitalCreateRequest;
 import com.dentallink.domain.hospital.dto.request.HospitalScheduleCreateRequest;
@@ -16,7 +16,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import static com.dentallink.common.response.ApiResponse.*;
+import static com.dentallink.common.response.CommonApiResponse.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,7 +27,7 @@ public class HospitalController {
     // 병원 등록
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMIN')")
-    public ResponseEntity<ApiResponse<HospitalCreateResponse>> createHospital(
+    public ResponseEntity<CommonApiResponse<HospitalCreateResponse>> createHospital(
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody HospitalCreateRequest request
     ) {
@@ -39,7 +39,7 @@ public class HospitalController {
 
     // 병원 전체 조회
     @GetMapping
-    public ResponseEntity<ApiResponse<PageResponse<HospitalListResponse>>> getAllHospitals(
+    public ResponseEntity<CommonApiResponse<PageResponse<HospitalListResponse>>> getAllHospitals(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
@@ -51,7 +51,7 @@ public class HospitalController {
 
     // 병원 단건 조회
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<HospitalDetailResponse>> getHospitalById(@PathVariable Long id) {
+    public ResponseEntity<CommonApiResponse<HospitalDetailResponse>> getHospitalById(@PathVariable Long id) {
         HospitalDetailResponse hospital = hospitalExternalService.findHospitalById(id);
         return success(
                 hospital, "병원 상세 정보를 조회했습니다."
@@ -61,7 +61,7 @@ public class HospitalController {
     // 병원 수정
     @PatchMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMIN', 'HOSPITAL')")
-    public ResponseEntity<ApiResponse<HospitalUpdateResponse>> updateHospital(
+    public ResponseEntity<CommonApiResponse<HospitalUpdateResponse>> updateHospital(
             @PathVariable Long id,
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody HospitalUpdateRequest hospitalUpdateRequest
@@ -76,7 +76,7 @@ public class HospitalController {
     // 병원 삭제
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMIN')")
-    public ResponseEntity<ApiResponse<Void>> deleteHospital(
+    public ResponseEntity<CommonApiResponse<Void>> deleteHospital(
             @PathVariable Long id,
             @AuthenticationPrincipal AuthUser authUser
     ) {
@@ -89,7 +89,7 @@ public class HospitalController {
     // 병원 일정 등록
     @PostMapping("/{hospitalId}/schedule")
     @PreAuthorize("hasAnyRole('ADMIN', 'HOSPITAL')")
-    public ResponseEntity<ApiResponse<HospitalScheduleCreateResponse>> createHospitalSchedule(
+    public ResponseEntity<CommonApiResponse<HospitalScheduleCreateResponse>> createHospitalSchedule(
             @PathVariable Long hospitalId,
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody HospitalScheduleCreateRequest request
@@ -105,7 +105,7 @@ public class HospitalController {
     // 병원 일정 수정
     @PatchMapping("/{hospitalId}/schedule")
     @PreAuthorize("hasAnyRole('ADMIN', 'HOSPITAL')")
-    public ResponseEntity<ApiResponse<HospitalScheduleUpdateResponse>> updateHospitalSchedule(
+    public ResponseEntity<CommonApiResponse<HospitalScheduleUpdateResponse>> updateHospitalSchedule(
             @PathVariable Long hospitalId,
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody HospitalScheduleUpdateRequest request
@@ -120,7 +120,7 @@ public class HospitalController {
     // 병원 일정 삭제
     @DeleteMapping("/{hospitalId}/schedule")
     @PreAuthorize("hasAnyRole('ADMIN', 'HOSPITAL')")
-    public ResponseEntity<ApiResponse<Void>> deleteHospitalSchedule(
+    public ResponseEntity<CommonApiResponse<Void>> deleteHospitalSchedule(
             @PathVariable Long hospitalId,
             @AuthenticationPrincipal AuthUser authUser
     ) {

--- a/src/main/java/com/dentallink/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/dentallink/domain/payment/controller/PaymentController.java
@@ -1,6 +1,6 @@
 package com.dentallink.domain.payment.controller;
 
-import com.dentallink.common.response.ApiResponse;
+import com.dentallink.common.response.CommonApiResponse;
 import com.dentallink.domain.payment.dto.request.PaymentRequest;
 import com.dentallink.domain.payment.dto.response.PaymentResponse;
 import com.dentallink.domain.payment.service.PaymentInternalService;
@@ -19,7 +19,7 @@ public class PaymentController {
     private final PaymentInternalService paymentInternalService;
 
     @PostMapping("/deposit")
-    public ResponseEntity<ApiResponse<PaymentResponse>> depositPoint(
+    public ResponseEntity<CommonApiResponse<PaymentResponse>> depositPoint(
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody PaymentRequest request
     ) {
@@ -29,6 +29,6 @@ public class PaymentController {
                 request.method()             // 결제 수단
         );
 
-        return ApiResponse.created(response, "포인트 충전에 성공했습니다.");
+        return CommonApiResponse.created(response, "포인트 충전에 성공했습니다.");
     }
 }

--- a/src/main/java/com/dentallink/domain/pointAccount/controller/PointAccountController.java
+++ b/src/main/java/com/dentallink/domain/pointAccount/controller/PointAccountController.java
@@ -1,6 +1,6 @@
 package com.dentallink.domain.pointAccount.controller;
 
-import com.dentallink.common.response.ApiResponse;
+import com.dentallink.common.response.CommonApiResponse;
 import com.dentallink.domain.pointAccount.dto.request.PointAccountRequest;
 import com.dentallink.domain.pointAccount.dto.response.*;
 import com.dentallink.domain.pointAccount.service.PointAccountInternalService;
@@ -31,34 +31,34 @@ public class PointAccountController {
 
     // 잔액 확인하기
     @GetMapping("/account")
-    public ResponseEntity<ApiResponse<PointAccountGetResponse>> getPointAccount(
+    public ResponseEntity<CommonApiResponse<PointAccountGetResponse>> getPointAccount(
             @AuthenticationPrincipal AuthUser authUser
     ) {
         PointAccountGetResponse response = pointAccountInternalService.getPointAccount(authUser.getUserId());
-        return ApiResponse.success(response, "잔액을 확인하였습니다.");
+        return CommonApiResponse.success(response, "잔액을 확인하였습니다.");
     }
 
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/deposit")
-    public ResponseEntity<ApiResponse<PointAccountDepositResponse>> depositPointAccount(
+    public ResponseEntity<CommonApiResponse<PointAccountDepositResponse>> depositPointAccount(
             @Valid @RequestBody PointAccountRequest request
     ) {
         PointAccountDepositResponse response = pointAccountInternalService.depositPointAccount(
                 request.accountId(),   //
                 request.amount()
         );
-        return ApiResponse.success(response, "포인트 충전에 성공했습니다.");
+        return CommonApiResponse.success(response, "포인트 충전에 성공했습니다.");
     }
 
 
     // 포인트를 현금으로 전환(지금은 그냥 point의 balance 값을 줄이는 용도)
     @PostMapping("/withdraw")
-    public ResponseEntity<ApiResponse<PointAccountWithdrawResponse>> withdrawPointAccount(
+    public ResponseEntity<CommonApiResponse<PointAccountWithdrawResponse>> withdrawPointAccount(
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody PointAccountRequest request
     ){
         PointAccountWithdrawResponse response = pointAccountInternalService.withdrawPointAccount(authUser.getUserId(), request.amount());
-        return ApiResponse.success(response, "포인트를 현금으로 전환했습니다.");
+        return CommonApiResponse.success(response, "포인트를 현금으로 전환했습니다.");
     }
 
 }

--- a/src/main/java/com/dentallink/domain/pointLog/controller/PointLogController.java
+++ b/src/main/java/com/dentallink/domain/pointLog/controller/PointLogController.java
@@ -1,6 +1,6 @@
 package com.dentallink.domain.pointLog.controller;
 
-import com.dentallink.common.response.ApiResponse;
+import com.dentallink.common.response.CommonApiResponse;
 import com.dentallink.common.response.PageResponse;
 import com.dentallink.domain.pointLog.dto.response.PointLogResponse;
 import com.dentallink.domain.pointLog.service.PointLogInternalService;
@@ -18,7 +18,7 @@ public class PointLogController {
     private final PointLogInternalService pointLogInternalService;
 
     @GetMapping("/logs/me")
-    public ResponseEntity<ApiResponse<PageResponse<PointLogResponse>>> getMyLogs(
+    public ResponseEntity<CommonApiResponse<PageResponse<PointLogResponse>>> getMyLogs(
             @AuthenticationPrincipal AuthUser authUser,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -26,6 +26,6 @@ public class PointLogController {
     ) {
         Long userId = authUser.getUserId();
         PageResponse<PointLogResponse> response = pointLogInternalService.getLogsByUser(userId, page, size, sort);
-        return ApiResponse.success(response, "내 포인트 로그 조회 성공");
+        return CommonApiResponse.success(response, "내 포인트 로그 조회 성공");
     }
 }

--- a/src/main/java/com/dentallink/domain/qna/controller/AnswerController.java
+++ b/src/main/java/com/dentallink/domain/qna/controller/AnswerController.java
@@ -1,6 +1,6 @@
 package com.dentallink.domain.qna.controller;
 
-import com.dentallink.common.response.ApiResponse;
+import com.dentallink.common.response.CommonApiResponse;
 import com.dentallink.domain.qna.dto.request.AnswerRequestDto;
 import com.dentallink.domain.qna.dto.response.AnswerResponseDto;
 import com.dentallink.domain.qna.service.AnswerService;
@@ -21,12 +21,12 @@ public class AnswerController {
 
     // 답변 등록 API answer create api
     @PostMapping
-    public ResponseEntity<ApiResponse<AnswerResponseDto.AnswerResponse>> createAnswer(
+    public ResponseEntity<CommonApiResponse<AnswerResponseDto.AnswerResponse>> createAnswer(
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody AnswerRequestDto.AnswerCreateRequest req
     ) {
         Long responderId = authUser.getUserId();    // 인증된 사용자 ID 사용
-        return ApiResponse.created(
+        return CommonApiResponse.created(
                 answerService.create(req.questionId(), responderId, req.content()),
                 "답변 등록 완료"
         );
@@ -34,10 +34,10 @@ public class AnswerController {
 
     // 답변 조회 API answer read api
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<AnswerResponseDto.AnswerResponse>> getAnswer(
+    public ResponseEntity<CommonApiResponse<AnswerResponseDto.AnswerResponse>> getAnswer(
             @PathVariable Long id
     ) {
-        return ApiResponse.success(
+        return CommonApiResponse.success(
                 AnswerResponseDto.AnswerResponse.from(answerService.get(id)),
                 "답변 조회 완료"
         );
@@ -45,24 +45,24 @@ public class AnswerController {
 
     // 답변 수정 API answer update api
     @PatchMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> updateAnswer(
+    public ResponseEntity<CommonApiResponse<Void>> updateAnswer(
             @PathVariable Long id,
             @AuthenticationPrincipal AuthUser authUser,
             @RequestBody AnswerRequestDto.AnswerUpdateRequest req
     ) {
         Long responderId = authUser.getUserId();    // 인증된 사용자 ID 사용
         answerService.update(id, responderId, req.content());
-        return ApiResponse.success(null, "답변 수정 완료");
+        return CommonApiResponse.success(null, "답변 수정 완료");
     }
 
     // 답변 삭제 API answer delete api
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> deleteAnswer(
+    public ResponseEntity<CommonApiResponse<Void>> deleteAnswer(
             @PathVariable Long id,
             @AuthenticationPrincipal AuthUser authUser
     ) {
         Long responderId = authUser.getUserId();    // 인증된 사용자 ID 사용
         answerService.delete(id, responderId);
-        return ApiResponse.deleteSuccess("답변 삭제 완료");
+        return CommonApiResponse.deleteSuccess("답변 삭제 완료");
     }
 }

--- a/src/main/java/com/dentallink/domain/qna/controller/QuestionController.java
+++ b/src/main/java/com/dentallink/domain/qna/controller/QuestionController.java
@@ -1,6 +1,6 @@
 package com.dentallink.domain.qna.controller;
 
-import com.dentallink.common.response.ApiResponse;
+import com.dentallink.common.response.CommonApiResponse;
 import com.dentallink.domain.qna.dto.request.QuestionRequestDto;
 import com.dentallink.domain.qna.dto.response.QuestionResponseDto;
 import com.dentallink.domain.qna.service.QuestionService;
@@ -21,12 +21,12 @@ public class QuestionController {
 
     // 문의 등록 API question create api
     @PostMapping
-    public ResponseEntity<ApiResponse<QuestionResponseDto.QuestionResponse>> createQuestion(
+    public ResponseEntity<CommonApiResponse<QuestionResponseDto.QuestionResponse>> createQuestion(
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody QuestionRequestDto.QuestionCreateRequest req
     ) {
         Long userId = authUser.getUserId();     // 인증된 사용자 ID 사용
-        return ApiResponse.created(
+        return CommonApiResponse.created(
                 questionService.create(userId, req.hospitalId(), req.title(), req.content()),
                 "문의 등록 완료"
         );
@@ -34,10 +34,10 @@ public class QuestionController {
 
     // 문의 조회 APi question read api
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<QuestionResponseDto.QuestionResponse>> getQuestion(
+    public ResponseEntity<CommonApiResponse<QuestionResponseDto.QuestionResponse>> getQuestion(
             @PathVariable Long id
     ) {
-        return ApiResponse.success(
+        return CommonApiResponse.success(
                 QuestionResponseDto.QuestionResponse.from(questionService.getWithAnswers(id)),
                 "문의 조회 완료"
         );
@@ -45,7 +45,7 @@ public class QuestionController {
 
     // 문의 수정 API question update api
     @PatchMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> updateQuestion(
+    public ResponseEntity<CommonApiResponse<Void>> updateQuestion(
             // todo 보안 취약점 확인
             @PathVariable Long id,
             @AuthenticationPrincipal AuthUser authUser,
@@ -53,18 +53,18 @@ public class QuestionController {
     ) {
         Long userId = authUser.getUserId();     // 인증된 사용자 ID 사용
         questionService.update(id, userId, req.title(), req.content());
-        return ApiResponse.success(null, "문의 수정 완료");
+        return CommonApiResponse.success(null, "문의 수정 완료");
     }
 
     // 문의 삭제 API question delete api
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> deleteQuestion(
+    public ResponseEntity<CommonApiResponse<Void>> deleteQuestion(
             // todo 보안 취약점 확인
             @PathVariable Long id,
             @AuthenticationPrincipal AuthUser authUser
     ) {
         Long userId = authUser.getUserId();     // 인증된 사용자 ID 사용
         questionService.delete(id, userId);
-        return ApiResponse.deleteSuccess("문의 삭제 완료");
+        return CommonApiResponse.deleteSuccess("문의 삭제 완료");
     }
 }

--- a/src/main/java/com/dentallink/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/dentallink/domain/reservation/controller/ReservationController.java
@@ -1,7 +1,6 @@
 package com.dentallink.domain.reservation.controller;
 
-
-import com.dentallink.common.response.ApiResponse;
+import com.dentallink.common.response.CommonApiResponse;
 import com.dentallink.common.response.PageResponse;
 import com.dentallink.domain.reservation.dto.AvailableTimeSlotResponse;
 import com.dentallink.domain.reservation.dto.ReservationCreateRequest;
@@ -9,6 +8,11 @@ import com.dentallink.domain.reservation.dto.ReservationResponse;
 import com.dentallink.domain.reservation.dto.ReservationUpdateStatusRequest;
 import com.dentallink.domain.reservation.service.ReservationInternalService;
 import com.dentallink.domain.user.dto.security.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +30,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 
+@Tag(name = "예약 관리", description = "치과 예약 관련 API")
 @RestController
 @RequestMapping("/api/reservations")
 @RequiredArgsConstructor
@@ -34,56 +39,91 @@ public class ReservationController {
 
     private final ReservationInternalService reservationService;
 
-    //예약 생성
+    @Operation(summary = "예약 생성", description = "새로운 치과 예약을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "예약 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PostMapping
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiResponse<ReservationResponse>> createReservation(
+    public ResponseEntity<CommonApiResponse<ReservationResponse>> createReservation(
+            @Parameter(description = "예약 생성 정보")
             @RequestBody @Valid ReservationCreateRequest request,
             @AuthenticationPrincipal AuthUser authUser) {
 
         ReservationResponse response = reservationService.createReservation(request, authUser.getUserId());
-        return ApiResponse.created(response, "예약 생성 성공");
+        return CommonApiResponse.created(response, "예약 생성 성공");
     }
 
-    //예약 가능 시간 조회 (인증 불필요)
+    @Operation(summary = "예약 가능 시간 조회",
+            description = "특정 병원의 특정 날짜에 예약 가능한 시간을 조회합니다. 인증 불필요")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
     @GetMapping("/available-slots")
-    public ResponseEntity<ApiResponse<List<AvailableTimeSlotResponse>>> getAvailableTimePeriod(
+    public ResponseEntity<CommonApiResponse<List<AvailableTimeSlotResponse>>> getAvailableTimePeriod(
+            @Parameter(description = "병원 ID", required = true)
             @RequestParam @Min(1) Long hospitalId,
+            @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", required = true)
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
 
         List<AvailableTimeSlotResponse> availableSlots = reservationService.getAvailableTimePeriod(hospitalId, date);
-        return ApiResponse.success(availableSlots, "예약 가능 시간 조회 성공");
+        return CommonApiResponse.success(availableSlots, "예약 가능 시간 조회 성공");
     }
 
-    //예약 단건 조회 (본인, 병원 관리자, 시스템 관리자만 가능)
+    @Operation(summary = "예약 단건 조회",
+            description = "예약 ID로 특정 예약 정보를 조회합니다. 본인, 병원 관리자, 시스템 관리자만 가능")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "예약을 찾을 수 없음")
+    })
     @GetMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiResponse<ReservationResponse>> getReservation(
+    public ResponseEntity<CommonApiResponse<ReservationResponse>> getReservation(
+            @Parameter(description = "예약 ID")
             @PathVariable Long id,
             @AuthenticationPrincipal AuthUser authUser) {
 
         ReservationResponse response = reservationService.getReservation(id, authUser.getUserId());
-        return ApiResponse.success(response, "예약 조회 성공");
+        return CommonApiResponse.success(response, "예약 조회 성공");
     }
 
-    //내 예약 목록 조회
+    @Operation(summary = "내 예약 목록 조회",
+            description = "로그인한 사용자의 예약 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @GetMapping("/my")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiResponse<PageResponse<ReservationResponse>>> getMyReservations(
+    public ResponseEntity<CommonApiResponse<PageResponse<ReservationResponse>>> getMyReservations(
             @AuthenticationPrincipal AuthUser authUser,
+            @Parameter(description = "페이지 정보 (page, size, sort)")
             @PageableDefault(size = 10, sort = "appointmentDate", direction = Sort.Direction.DESC)
             Pageable pageable) {
 
         Page<ReservationResponse> reservations = reservationService.getMyReservations(authUser.getUserId(), pageable);
-        return ApiResponse.pageSuccess(reservations, "내 예약 목록 조회 성공");
+        return CommonApiResponse.pageSuccess(reservations, "내 예약 목록 조회 성공");
     }
 
-    //병원별 예약 목록 조회 (병원 관리자, 시스템 관리자만 가능)
+    @Operation(summary = "병원별 예약 목록 조회",
+            description = "특정 병원의 예약 목록을 조회합니다. 병원 관리자, 시스템 관리자만 가능")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음")
+    })
     @GetMapping
     @PreAuthorize("hasAnyRole('ADMIN', 'HOSPITAL')")
-    public ResponseEntity<ApiResponse<PageResponse<ReservationResponse>>> getHospitalReservations(
+    public ResponseEntity<CommonApiResponse<PageResponse<ReservationResponse>>> getHospitalReservations(
+            @Parameter(description = "병원 ID", required = true)
             @RequestParam Long hospitalId,
             @AuthenticationPrincipal AuthUser authUser,
+            @Parameter(description = "페이지 정보 (page, size, sort)")
             @PageableDefault(size = 10, sort = "appointmentDate", direction = Sort.Direction.DESC)
             Pageable pageable) {
 
@@ -92,14 +132,24 @@ public class ReservationController {
                 authUser.getUserId(),
                 pageable
         );
-        return ApiResponse.pageSuccess(reservations, "병원 예약 목록 조회 성공");
+        return CommonApiResponse.pageSuccess(reservations, "병원 예약 목록 조회 성공");
     }
 
-    //예약 상태 변경 (병원 관리자, 시스템 관리자만 가능)
+    @Operation(summary = "예약 상태 변경",
+            description = "예약 상태를 변경합니다. 병원 관리자, 시스템 관리자만 가능")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "상태 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "예약을 찾을 수 없음")
+    })
     @PatchMapping("/{id}/status")
     @PreAuthorize("hasAnyRole('ADMIN', 'HOSPITAL')")
-    public ResponseEntity<ApiResponse<ReservationResponse>> updateReservationStatus(
+    public ResponseEntity<CommonApiResponse<ReservationResponse>> updateReservationStatus(
+            @Parameter(description = "예약 ID")
             @PathVariable @Min(1) Long id,
+            @Parameter(description = "변경할 상태 정보")
             @RequestBody @Valid ReservationUpdateStatusRequest request,
             @AuthenticationPrincipal AuthUser authUser) {
 
@@ -108,17 +158,25 @@ public class ReservationController {
                 request,
                 authUser.getUserId()
         );
-        return ApiResponse.success(response, "예약 상태 변경 성공");
+        return CommonApiResponse.success(response, "예약 상태 변경 성공");
     }
 
-    //예약 취소 (본인만 가능)
+    @Operation(summary = "예약 취소",
+            description = "예약을 취소합니다. 본인만 가능")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "취소 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "예약을 찾을 수 없음")
+    })
     @DeleteMapping("/{id}")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiResponse<Void>> cancelReservation(
+    public ResponseEntity<CommonApiResponse<Void>> cancelReservation(
+            @Parameter(description = "예약 ID")
             @PathVariable @Min(1) Long id,
             @AuthenticationPrincipal AuthUser authUser) {
 
         reservationService.cancelReservation(id, authUser.getUserId());
-        return ApiResponse.deleteSuccess("예약 취소 성공");
+        return CommonApiResponse.deleteSuccess("예약 취소 성공");
     }
 }

--- a/src/main/java/com/dentallink/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/dentallink/domain/review/controller/ReviewController.java
@@ -1,6 +1,6 @@
 package com.dentallink.domain.review.controller;
 
-import com.dentallink.common.response.ApiResponse;
+import com.dentallink.common.response.CommonApiResponse;
 import com.dentallink.common.response.PageResponse;
 import com.dentallink.domain.review.dto.request.ReviewCreateRequest;
 import com.dentallink.domain.review.dto.request.ReviewUpdateRequest;
@@ -14,7 +14,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import static com.dentallink.common.response.ApiResponse.*;
+import static com.dentallink.common.response.CommonApiResponse.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,7 +24,7 @@ public class ReviewController {
 
     // 리뷰 등록
     @PostMapping("/hospitals/{hospitalId}/reviews")
-    public ResponseEntity<ApiResponse<ReviewCreateResponse>> createReview(
+    public ResponseEntity<CommonApiResponse<ReviewCreateResponse>> createReview(
             @PathVariable Long hospitalId,
             @RequestParam Long reservationId,
             @AuthenticationPrincipal AuthUser authUser,
@@ -40,7 +40,7 @@ public class ReviewController {
 
     // 병원 별 리뷰 목록 조회
     @GetMapping("/hospitals/{hospitalId}/reviews")
-    public ResponseEntity<ApiResponse<PageResponse<ReviewListResponse>>> getAllReviews(
+    public ResponseEntity<CommonApiResponse<PageResponse<ReviewListResponse>>> getAllReviews(
             @PathVariable Long hospitalId,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size
@@ -53,7 +53,7 @@ public class ReviewController {
 
     // 리뷰 상세 조회
     @GetMapping("/reviews/{id}")
-    public ResponseEntity<ApiResponse<ReviewDetailResponse>> getReviewById(
+    public ResponseEntity<CommonApiResponse<ReviewDetailResponse>> getReviewById(
             @PathVariable Long id
     ) {
         ReviewDetailResponse review = reviewExternalService.findReviewById(id);
@@ -64,7 +64,7 @@ public class ReviewController {
 
     // 리뷰 수정
     @PatchMapping("/reviews/{id}")
-    public ResponseEntity<ApiResponse<ReviewUpdateResponse>> updateReview(
+    public ResponseEntity<CommonApiResponse<ReviewUpdateResponse>> updateReview(
             @PathVariable Long id,
             @AuthenticationPrincipal AuthUser authUser,
             @RequestBody ReviewUpdateRequest reviewUpdateRequest
@@ -77,7 +77,7 @@ public class ReviewController {
 
     // 리뷰 삭제
     @DeleteMapping("/reviews/{id}")
-    public ResponseEntity<ApiResponse<ReviewDeleteResponse>> deleteReviewById(
+    public ResponseEntity<CommonApiResponse<ReviewDeleteResponse>> deleteReviewById(
             @PathVariable Long id,
             @AuthenticationPrincipal AuthUser authUser
     ) {
@@ -90,7 +90,7 @@ public class ReviewController {
     // 리뷰 상태 변경
     @PatchMapping("/reviews/{id}/status")
     @PreAuthorize("hasAnyRole('ADMIN')")
-    public ResponseEntity<ApiResponse<ReviewStatusResponse>> updateReviewStatus(
+    public ResponseEntity<CommonApiResponse<ReviewStatusResponse>> updateReviewStatus(
             @PathVariable Long id,
             @RequestBody ReviewUpdateStatusRequest request,
             @AuthenticationPrincipal AuthUser authUser // 관리자 인증정보

--- a/src/main/java/com/dentallink/domain/user/controller/UserAdminController.java
+++ b/src/main/java/com/dentallink/domain/user/controller/UserAdminController.java
@@ -1,7 +1,7 @@
 package com.dentallink.domain.user.controller;
 
 import com.dentallink.common.response.PageResponse;
-import com.dentallink.common.response.ApiResponse;
+import com.dentallink.common.response.CommonApiResponse;
 import com.dentallink.domain.user.dto.request.UserSignupRequest;
 import com.dentallink.domain.user.dto.response.UserResponse;
 import com.dentallink.domain.user.service.UserInternalService;
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import static com.dentallink.common.response.ApiResponse.success;
+import static com.dentallink.common.response.CommonApiResponse.success;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,7 +25,7 @@ public class UserAdminController {
     // 특정 유저 열람
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/users/{userId}")
-    public ResponseEntity<ApiResponse<UserResponse>> getOneUser(
+    public ResponseEntity<CommonApiResponse<UserResponse>> getOneUser(
             @PathVariable("userId") Long userId
     ) {
         return success(
@@ -37,7 +37,7 @@ public class UserAdminController {
     // 모든 유저 열람
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/users")
-    public ResponseEntity<ApiResponse<PageResponse<UserResponse>>> getUsers(
+    public ResponseEntity<CommonApiResponse<PageResponse<UserResponse>>> getUsers(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
@@ -49,7 +49,7 @@ public class UserAdminController {
 
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/admin/hospitals/signup")
-    public ResponseEntity<ApiResponse<UserResponse>> signup(
+    public ResponseEntity<CommonApiResponse<UserResponse>> signup(
             @Valid @RequestBody UserSignupRequest request
     ) {
         return success(
@@ -59,7 +59,7 @@ public class UserAdminController {
     }
 
     @PostMapping("/admin")
-    public ResponseEntity<ApiResponse<UserResponse>> createTestAdmin(){
+    public ResponseEntity<CommonApiResponse<UserResponse>> createTestAdmin(){
         return success(
                 userInternalService.createTestAdmin(),
                 "테스트용 관리자 계정이 생성되었습니다."

--- a/src/main/java/com/dentallink/domain/user/controller/UserController.java
+++ b/src/main/java/com/dentallink/domain/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.dentallink.domain.user.controller;
 
-import com.dentallink.common.response.ApiResponse;
+import com.dentallink.common.response.CommonApiResponse;
 import com.dentallink.domain.user.dto.request.UserDeleteRequest;
 import com.dentallink.domain.user.dto.request.UserSignupRequest;
 import com.dentallink.domain.user.dto.request.UserUpdatePasswordRequest;
@@ -14,8 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import static com.dentallink.common.response.ApiResponse.created;
-import static com.dentallink.common.response.ApiResponse.success;
+import static com.dentallink.common.response.CommonApiResponse.created;
+import static com.dentallink.common.response.CommonApiResponse.success;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,7 +26,7 @@ public class UserController {
 
     // 회원가입
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<UserResponse>> signup(
+    public ResponseEntity<CommonApiResponse<UserResponse>> signup(
              @Valid @RequestBody UserSignupRequest request
     ) {
         return created(
@@ -36,7 +36,7 @@ public class UserController {
     }
     // 정보수정
     @PatchMapping("/me")
-    public ResponseEntity<ApiResponse<UserResponse>> updateUser(
+    public ResponseEntity<CommonApiResponse<UserResponse>> updateUser(
             @Valid @RequestBody UserUpdateRequest request,
             @AuthenticationPrincipal AuthUser authUser
     ) {
@@ -47,7 +47,7 @@ public class UserController {
     }
     // 비밀번호 수정
     @PutMapping("/password")
-    public ResponseEntity<ApiResponse<Void>> changePassword(
+    public ResponseEntity<CommonApiResponse<Void>> changePassword(
             @Valid @RequestBody UserUpdatePasswordRequest request,
             @AuthenticationPrincipal AuthUser authUser
     ) {
@@ -58,7 +58,7 @@ public class UserController {
     }
     // 회원탈퇴
     @DeleteMapping("/withdraw")
-    public ResponseEntity<ApiResponse<Void>> withdraw(
+    public ResponseEntity<CommonApiResponse<Void>> withdraw(
             @Valid @RequestBody UserDeleteRequest request,
             @AuthenticationPrincipal AuthUser authUser
     ) {
@@ -69,7 +69,7 @@ public class UserController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<UserResponse>> getUser(
+    public ResponseEntity<CommonApiResponse<UserResponse>> getUser(
             @AuthenticationPrincipal AuthUser authUser
     ) {
         return success(


### PR DESCRIPTION
- ReservationController에 Swagger 어노테이션 추가 (@Tag, @Operation, @ApiResponses, @Parameter)
- ApiResponse를 CommonApiResponse로 변경하여 Swagger ApiResponse와 충돌 해결
- API 문서화 개선

## 🎖️ Outline
<!--어떤 작업을 진행하였는지 정리해 주세요. "[ ]" 사이 띄어쓰기를 지우고 'x'(소문자 영어)를 입력하여 체크할 수 있습니다.-->
- [ ] 💫 Feature : 기능 구현
- [ ] 👾 Bug Fix : 오류 수정
- [ ] 🔨 Refactor : 리팩터링
- [ ] ⚙️ Chore : 기타 유지보수
- [ ] 📝 Documentation : 문서 작업

## 📍 Issue Number
<!-- 이슈 번호를 적어주세요.-->
- Closes #이슈번호

## 📄 Description
<!--해당 PR에 대한 자세한 설명을 적어주세요.-->
<!-- 추천하는 방법은 커밋해시-개별 커밋의 고유 식별 번호-를 작성하고 설명하는 방법입니다.-->
<!-- 예) 761e811-커밋 해시를 사용하면 자동으로 인식합니다.- / reaeMe.md 작성.-->

## 💗 For Reviewers
<!-- 리뷰어들이 더 주의깊게 보면 좋을 곳을 얘기해 주세요. -필수X- -->

## ✔️ PR Checklist
<!--PR은 필수적으로 다음의 체크리스트를 만족해야 합니다! 확인해 주세요. "[ ]" 사이 띄어쓰기를 지우고 'x'(소문자 영어)를 입력하여 완료할 수 있습니다.-->
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
