### PR TITLE
fix: 채팅 메시지 타입 확인 추가 및 상담사 세션 선택 개선

### DIFF
--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -1561,7 +1561,18 @@ function connectFabChatbot() {
                         if (body && body.sessionId && !window.fabChatSessionId) {
                             window.fabChatSessionId = body.sessionId;
                         }
-                        appendFabChatMessage('bot', body?.content || '');
+
+                        // 메시지 타입 확인 (상담사 vs AI)
+                        const messageType = body?.type || 'AI';
+                        let sender = 'bot'; // 기본값은 챗봇
+
+                        if (messageType === 'CONSULTANT') {
+                            sender = 'consultant'; // 상담사 메시지
+                        } else if (messageType === 'SYSTEM') {
+                            sender = 'system'; // 시스템 메시지
+                        }
+
+                        appendFabChatMessage(sender, body?.content || '');
                     } catch (e) {
                         console.error('Message parse error:', e);
                         appendFabChatMessage('bot', message.body || '');
@@ -2083,8 +2094,17 @@ function connectChatbot() {
                         } else if (body?.actionType === 'SESSION_CLOSED') {
                             handleSessionClosed(body);
                         } else {
-                            // 일반 메시지
-                            appendChatMessage('bot', body?.content || '');
+                            // 메시지 타입 확인 (상담사 vs AI)
+                            const messageType = body?.type || 'AI';
+                            let sender = 'bot'; // 기본값은 챗봇
+
+                            if (messageType === 'CONSULTANT') {
+                                sender = 'consultant'; // 상담사 메시지
+                            } else if (messageType === 'SYSTEM') {
+                                sender = 'system'; // 시스템 메시지
+                            }
+
+                            appendChatMessage(sender, body?.content || '');
                         }
 
                         // 사용자가 스크롤 중이면 새 메시지 표시, 아니면 자동 스크롤
@@ -2730,8 +2750,11 @@ function pickSession(sessionId) {
             headers['Authorization'] = `Bearer ${authToken}`;
         }
 
-        // 메시지 전송 (실제 UI 업데이트는 /user/queue/assigned 응답에서)
-        consultantStompClient.send('/app/consultant/pick', headers, JSON.stringify({}));
+        // 메시지 전송 (sessionId를 반드시 포함해야 함)
+        const payload = {
+            sessionId: sessionId
+        };
+        consultantStompClient.send('/app/consultant/pick', headers, JSON.stringify(payload));
         console.log('세션 수락 요청 전송:', sessionId);
     } catch (error) {
         console.error('Error picking session:', error);


### PR DESCRIPTION
  - pickSession()에 sessionId를 STOMP 페이로드에 포함하여 상담사 세션 할당 문제 해결
  - 메시지 수신 시 messageType 확인하여 상담사(CONSULTANT)/AI/시스템 메시지 구분
  - FAB 챗봇과 메인 챗봇 페이지 모두에 메시지 타입 검사 적용
  - CSS 기반 메시지 구분 표시 활성화 (상담사 메시지는 'consultant' 클래스로 표시)

  이를 통해 고객과 상담사의 메시지를 시각적으로 구분할 수 있게 됨

## 🎖️ Outline
<!--어떤 작업을 진행하였는지 정리해 주세요. "[ ]" 사이 띄어쓰기를 지우고 'x'(소문자 영어)를 입력하여 체크할 수 있습니다.-->
- [ ] 💫 Feature : 기능 구현
- [ ] 👾 Bug Fix : 오류 수정
- [ ] 🔨 Refactor : 리팩터링
- [ ] ⚙️ Chore : 기타 유지보수
- [ ] 📝 Documentation : 문서 작업

## 📍 Issue Number
<!-- 이슈 번호를 적어주세요.-->
- Closes #이슈번호

## 📄 Description
<!--해당 PR에 대한 자세한 설명을 적어주세요.-->
<!-- 추천하는 방법은 커밋해시-개별 커밋의 고유 식별 번호-를 작성하고 설명하는 방법입니다.-->
<!-- 예) 761e811-커밋 해시를 사용하면 자동으로 인식합니다.- / reaeMe.md 작성.-->

## 💗 For Reviewers
<!-- 리뷰어들이 더 주의깊게 보면 좋을 곳을 얘기해 주세요. -필수X- -->

## ✔️ PR Checklist
<!--PR은 필수적으로 다음의 체크리스트를 만족해야 합니다! 확인해 주세요. "[ ]" 사이 띄어쓰기를 지우고 'x'(소문자 영어)를 입력하여 완료할 수 있습니다.-->
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
